### PR TITLE
Feature: Collect footnotes from multiple fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,13 @@ echo $page->text()->withoutFootnotes();
 
 // returns only the footnotes container
 echo $page->text()->onlyFootnotes();
+
+// returns the text with footnotes references, no footnotes container, but stores the footnotes container for later use
+echo $page->text1()->collectFootnotes();
+echo $page->text2()->collectFootnotes();
+
+// returns the footnotes container with all collected footnotes and clears the memory
+echo Footnotes::footnotes();
 ```
 
 <br/>

--- a/index.php
+++ b/index.php
@@ -1,5 +1,7 @@
 <?php
 
+use Kirby\Cms\App as Kirby;
+
 require_once __DIR__ . '/lib/footnotes.php';
 
 Kirby::plugin('sylvainjule/footnotes', [
@@ -20,6 +22,10 @@ Kirby::plugin('sylvainjule/footnotes', [
         },
         'withoutFootnotes' => function($field) {
             return Footnotes::convert($field->text(), false, true);
+        },
+        'collectFootnotes' => function($field) {
+            $start = count(Footnotes::$footnotes) + 1;
+            return Footnotes::convert($field->text(), false, true, false, true, $start);
         },
         'onlyFootnotes' => function($field) {
             return Footnotes::convert($field->text(), false, false, true);

--- a/lib/footnotes.php
+++ b/lib/footnotes.php
@@ -39,7 +39,7 @@ class Footnotes {
                 return $output;
             }
             elseif($without) { // return only the text with footnotes' numbers
-                self::$footnotes += $notesArr;
+                self::$footnotes = array_merge(self::$footnotes, $notesArr);
                 return $text;
             }
             else {

--- a/lib/footnotes.php
+++ b/lib/footnotes.php
@@ -1,6 +1,7 @@
 <?php
 
 class Footnotes {
+    public static array $footnotes = [];
 
     public static function convert($text, $remove = false, $without = false, $only = false, $kt = true, $startAt = 1, $unwrapped = false) {
         $text = $kt ? kirbytext($text) : $text;
@@ -38,6 +39,7 @@ class Footnotes {
                 return $output;
             }
             elseif($without) { // return only the text with footnotes' numbers
+                self::$footnotes += $notesArr;
                 return $text;
             }
             else {
@@ -46,6 +48,17 @@ class Footnotes {
         }
         else {
             return $only ? '' : $text;
+        }
+    }
+
+    public static function footnotes($purge = true, $unwrapped = false) {
+        $footnotes = self::$footnotes;
+        if($purge) self::$footnotes = [];
+
+        if($unwrapped) {
+            return $footnotes;
+        } else {
+            return snippet('footnotes_container', ['footnotes' => join("", $footnotes)], true);
         }
     }
 


### PR DESCRIPTION
This PR allows the workflow of calling multiple times `$field->collectFootnotes()` and then once (like at the end of the page) a `Footnotes::footnotes()` to get all collected notes.

It's similar to the block methods, but I found it easier to think about this way. Feel free to either ignore it, take some inspiration, merge it, or whatever :)

PS: thanks for the plugin :)