### PR TITLE
Improve accessibility

### DIFF
--- a/snippets/entry.php
+++ b/snippets/entry.php
@@ -2,7 +2,7 @@
     <?php echo $note ?>
     <?php if(option('sylvainjule.footnotes.back') && option('sylvainjule.footnotes.links')): ?>
         <span class="footnotereverse">
-            <a href="#fnref-<?php echo $count ?>">
+            <a href="#fnref-<?php echo $count ?>" title="Back to content <?php echo $count ?>">
                 <?php echo option('sylvainjule.footnotes.back') ?>
             </a>
         </span>

--- a/snippets/reference.php
+++ b/snippets/reference.php
@@ -1,5 +1,5 @@
 <?php if(option('sylvainjule.footnotes.links')): ?>
-<sup class="footnote"><a id="fnref-<?php echo $count ?>" href="#fn-<?php echo $count ?>"><?php echo $order ?></a></sup>
+<sup class="footnote"><a id="fnref-<?php echo $count ?>" href="#fn-<?php echo $count ?>" aria-describedby="fn-<?php echo $count ?>"><?php echo $order ?></a></sup>
 <?php else: ?>
 <sup id="fnref-<?php echo $count ?>" class="footnote" data-ref="#fn-<?php echo $count ?>"><?php echo $order ?></sup>
 <?php endif; ?>


### PR DESCRIPTION
Hi there!

Following [Access42 recommendations regarding footnotes accessibility (in  French)](https://access42.net/comment-integrer-notes-bas-page-accessibles/), I tried to improve kirby-footnotes output.

There's a leftover since the back ton content link's `title` attribute is hardcoded, and I'm pretty sure there's a better way to handle this.

I don't know if that's something that I could do by overriding snippets locally, but thought it might be valuable for you as a starting point :)