### PR TITLE
Add optional manual footnote pinning ([^N: text])

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,14 +33,43 @@ Alternatively, you can install it with composer: ```composer require sylvainjule
 
 Use the footnotes method on your field: `$page->text()->footnotes()` or `$page->text()->ft()` (no need to call `->kirbytext()` before or after, this method will take care of it).
 
-Adding footnotes to your Kirbytext field is simple. Just type them inline in your post in square brackets like this:
+Adding footnotes to your Kirbytext field is simple. Just type them inline in your post in square brackets, starting with a caret (`^`). There are three ways to number them — mix and match freely within the same text:
+
+### Auto (recommended)
+
+The original, unopinionated syntax. Just write the footnote inline and it gets numbered automatically, in the order it appears in the text:
 
 ```
 [^This is a footnote.]
 [^ This is another.]
 ```
 
-Each footnote must start with a caret (`^`) and will be numbered automatically. Footnotes can contain anything you want including links or images, but please note that **you should not include unescaped square brackets [] inside a footnote.**
+Stick with this unless you have a specific reason to control the number yourself — it's the simplest option and needs no bookkeeping.
+
+### Manual
+
+Pin a footnote to an explicit number by prefixing the note with `N:` (the number, a colon, then the text):
+
+```
+[^1: This is always footnote number one.]
+[^2: This is always footnote number two.]
+```
+
+Useful when the footnote number needs to stay stable regardless of where the reference sits in the text (for example, referencing footnote numbers from an external source, or keeping a specific note pinned to "1" across edits).
+
+Reusing the same pin elsewhere in the text (`[^1:]`, with or without repeating the text) references that same footnote again instead of creating a duplicate — the entry renders once, with one lettered backlink (a, b, c, …) per place it was referenced from.
+
+### Mix
+
+Pin the notes where the number matters, leave the rest on auto — they'll number themselves around whatever's pinned, in the order they appear:
+
+```
+Some text.[^ This becomes footnote 2.] More text.[^1: This is pinned to footnote 1.] Even more.[^ This becomes footnote 3.]
+```
+
+The footnotes list at the bottom is always sorted by number (1, 2, 3, …), even when a pin makes the reference order in the text non-sequential.
+
+Footnotes can contain anything you want including links or images, but please note that **you should not include unescaped square brackets [] inside a footnote.**
 
 If you add square brackets in a note (`This is a truncated […] quote` for example), you must escape the closing bracket belonging to the note:
 

--- a/lib/footnotes.php
+++ b/lib/footnotes.php
@@ -6,11 +6,7 @@ class Footnotes {
     public static function convert($text, $remove = false, $without = false, $only = false, $kt = true, $startAt = 1, $unwrapped = false) {
         $text = $kt ? kirbytext($text, ['parent' => $text->parent()]) : $text;
 
-        $matches    = null;
-        $references = null;
-        $notes      = null;
-        $notesStr   = '';
-        $notesArr   = [];
+        $matches = null;
 
         // if there are notes
         if(preg_match_all('/\[(\^.*?)(?<!\\\)\]/s', $text, $matches)) {
@@ -20,18 +16,73 @@ class Footnotes {
             $references = $matches[0];
             $notes      = self::strip($matches);
 
-            $count = $startAt;
-            $order = $startAt;
+            // Pass 1: resolve every explicitly pinned number ([^N: Text]) to
+            // its footnote text. The first non-empty text for a given pin
+            // wins; later occurrences of the same pin are references to
+            // that same footnote (see pass 2), letting a manually pinned
+            // note be reused multiple times in the text.
+            $reserved    = [];
+            $definitions = [];
+            foreach($notes as $note) {
+                if($note['pin'] === null) {
+                    continue;
+                }
+
+                $order = $note['pin'];
+                if(!in_array($order, $reserved, true)) {
+                    $reserved[] = $order;
+                }
+
+                $hasDefinition = array_key_exists($order, $definitions) && trim($definitions[$order]) !== '';
+                if(!$hasDefinition) {
+                    $definitions[$order] = $note['note'];
+                }
+            }
+
+            // Pass 2: walk the notes in text order. `count` is a plain
+            // sequential index, used only for unique reference/backlink
+            // anchor ids. `order` is the number that's actually displayed
+            // and can be pinned out of sequence; auto-numbered notes are
+            // assigned the next free number, skipping reserved pins.
+            // Every reference id that resolves to the same `order` is
+            // collected, so a reused pin renders as a single footnote entry
+            // with one backlink per place it was referenced from.
+            $count       = $startAt;
+            $next        = $startAt;
+            $refsByOrder = [];
 
             foreach($notes as $key => $note) {
-                $data       = ['count' => $count, 'order' => $order, 'note' => $note];
-                $text       = self::str_replace_first($references[$key], snippet(option('sylvainjule.footnotes.snippet.reference'), $data, true), $text);
-                $notesStr  .= snippet(option('sylvainjule.footnotes.snippet.entry'), $data, true);
-                $notesArr[] = snippet(option('sylvainjule.footnotes.snippet.entry'), $data, true);
+                if($note['pin'] !== null) {
+                    $order = $note['pin'];
+                } else {
+                    while(in_array($next, $reserved, true) || array_key_exists($next, $definitions)) {
+                        $next++;
+                    }
+                    $order = $next;
+                    $definitions[$order] = $note['note'];
+                }
+
+                $refsByOrder[$order][] = $count;
+
+                $data = ['count' => $count, 'order' => $order];
+                $text = self::str_replace_first($references[$key], snippet(option('sylvainjule.footnotes.snippet.reference'), $data, true), $text);
 
                 $count++;
-                $order++;
             }
+
+            // The footnotes list is always sorted by displayed number, even
+            // when pins reorder it relative to the text.
+            ksort($definitions);
+
+            $notesByOrder = [];
+            foreach($definitions as $order => $noteText) {
+                $refs = $refsByOrder[$order] ?? [$order];
+                $data = ['count' => $refs[0], 'refs' => $refs, 'order' => $order, 'note' => $noteText];
+                $notesByOrder[$order] = snippet(option('sylvainjule.footnotes.snippet.entry'), $data, true);
+            }
+
+            $notesArr = array_values($notesByOrder);
+            $notesStr = implode('', $notesArr);
 
             $output = $unwrapped ? $notesArr : snippet(option('sylvainjule.footnotes.snippet.container'), ['footnotes' => $notesStr], true);
 
@@ -68,11 +119,24 @@ class Footnotes {
     public static function matches($text) {
         return preg_match_all('/\[(\^.*?)\]/s', $text, $matches);
     }
+
+    /**
+     * Extracts each note's raw content and, if present, an explicit pin
+     * number written as `[^N: Text]`. Notes without that prefix stay
+     * unpinned (`pin` is null) and get auto-numbered by `convert()`.
+     */
     public static function strip($matches) {
         return array_map(function($match) use($matches) {
-          $match = preg_replace('/\[(\^(.*?))(?<!\\\)\]/s', '\2', $match);
-          $match = str_replace(array('<p>','</p>'), '', kirbytext($match));
-          return $match;
+          $raw = preg_replace('/\[(\^(.*?))(?<!\\\)\]/s', '\2', $match);
+
+          $pin = null;
+          if(preg_match('/^(\d+):\s*(.*)$/s', $raw, $pinMatch)) {
+              $pin = (int) $pinMatch[1];
+              $raw = $pinMatch[2];
+          }
+
+          $note = str_replace(array('<p>','</p>'), '', kirbytext($raw));
+          return ['pin' => $pin, 'note' => $note];
         }, $matches[0]);
     }
     public static function remove($text, $matches) {

--- a/snippets/entry.php
+++ b/snippets/entry.php
@@ -1,10 +1,12 @@
-<li id="fn-<?php echo $count ?>" value="<?php echo $order ?>">
+<li id="fn-<?php echo $order ?>" value="<?php echo $order ?>">
     <?php echo $note ?>
     <?php if(option('sylvainjule.footnotes.back') && option('sylvainjule.footnotes.links')): ?>
+        <?php foreach($refs as $i => $refCount): ?>
         <span class="footnotereverse">
-            <a href="#fnref-<?php echo $count ?>" title="<?php echo option('sylvainjule.footnotes.back.title', t('footnotes.back.title')) ?> <?php echo $count ?>">
-                <?php echo option('sylvainjule.footnotes.back') ?>
+            <a href="#fnref-<?php echo $refCount ?>" title="<?php echo option('sylvainjule.footnotes.back.title', t('footnotes.back.title')) ?> <?php echo $order ?><?php echo count($refs) > 1 ? ' ' . chr(97 + $i) : '' ?>">
+                <?php echo option('sylvainjule.footnotes.back') ?><?php echo count($refs) > 1 ? '&nbsp;' . chr(97 + $i) : '' ?>
             </a>
         </span>
+        <?php endforeach; ?>
     <?php endif; ?>
 </li>

--- a/snippets/reference.php
+++ b/snippets/reference.php
@@ -1,5 +1,5 @@
 <?php if(option('sylvainjule.footnotes.links')): ?>
-<sup class="footnote"><a id="fnref-<?php echo $count ?>" href="#fn-<?php echo $count ?>" aria-describedby="fn-<?php echo $count ?>"><?php echo $order ?></a></sup>
+<sup class="footnote"><a id="fnref-<?php echo $count ?>" href="#fn-<?php echo $order ?>" aria-describedby="fn-<?php echo $order ?>"><?php echo $order ?></a></sup>
 <?php else: ?>
-<sup id="fnref-<?php echo $count ?>" class="footnote" data-ref="#fn-<?php echo $count ?>"><?php echo $order ?></sup>
+<sup id="fnref-<?php echo $count ?>" class="footnote" data-ref="#fn-<?php echo $order ?>"><?php echo $order ?></sup>
 <?php endif; ?>


### PR DESCRIPTION
## Summary

- Footnotes can now be pinned to an explicit number with `[^N: Text]`, while unpinned `[^ Text]` notes continue to number themselves automatically around whatever is pinned. Auto, Manual and Mix usage can be freely combined in the same text; the footnotes list is always sorted by the displayed number.
- A pinned footnote can also be reused: referencing the same `[^N:]` again elsewhere points at the same entry instead of creating a duplicate. The entry renders once, with one lettered backlink (a, b, c, …) per place it was referenced from; a note referenced only once keeps the original single-backlink markup.
- A duplicate pin (same `N` defined with different text) keeps the first definition and ignores the rest, rather than erroring or silently overwriting it.
- To make reuse possible, footnote entry/reference anchors now key off the displayed number rather than the internal reference counter, so multiple references can point at one shared entry.

Fully backwards compatible: text using only the original `[^ Text]` syntax renders identically to before.

See the updated "2. Basic usage" section in the README for the Auto/Manual/Mix syntax with examples.

## Test plan

- [ ] Auto-only text still numbers 1, 2, 3, … as before (regression check)
- [ ] `[^N: Text]` pins render at the requested number regardless of position in the text
- [ ] Mixing pinned and unpinned notes in the same text numbers correctly around the pins
- [ ] Reusing a pin (`[^N:]` after its first definition) renders one shared entry with multiple lettered backlinks
- [ ] A duplicate pin (same `N`, different text) keeps the first definition instead of erroring